### PR TITLE
[#3] 데이터 검색 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'org.postgresql:postgresql:42.6.0'

--- a/src/main/java/com/capston/favicon/application/DataServiceImpl.java
+++ b/src/main/java/com/capston/favicon/application/DataServiceImpl.java
@@ -22,4 +22,9 @@ public class DataServiceImpl implements DataService {
         return dataRepository.searchByText(text);
     }
 
+    @Override
+    public List<Data> searchWithCategory(String text, String category) {
+        return dataRepository.searchWithCategory(text, category);
+    }
+
 }

--- a/src/main/java/com/capston/favicon/application/DataServiceImpl.java
+++ b/src/main/java/com/capston/favicon/application/DataServiceImpl.java
@@ -1,0 +1,25 @@
+package com.capston.favicon.application;
+
+
+import com.capston.favicon.application.repository.DataService;
+import com.capston.favicon.domain.domain.Data;
+import com.capston.favicon.infrastructure.DataRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class DataServiceImpl implements DataService {
+
+    @Autowired
+    private DataRepository dataRepository;
+
+    @Override
+    public List<Data> search(String text) {
+        return dataRepository.searchByText(text);
+    }
+
+}

--- a/src/main/java/com/capston/favicon/application/repository/DataService.java
+++ b/src/main/java/com/capston/favicon/application/repository/DataService.java
@@ -1,0 +1,9 @@
+package com.capston.favicon.application.repository;
+
+import com.capston.favicon.domain.domain.Data;
+
+import java.util.List;
+
+public interface DataService {
+    List<Data> search(String text);
+}

--- a/src/main/java/com/capston/favicon/application/repository/DataService.java
+++ b/src/main/java/com/capston/favicon/application/repository/DataService.java
@@ -6,4 +6,5 @@ import java.util.List;
 
 public interface DataService {
     List<Data> search(String text);
+    List<Data> searchWithCategory(String text, String category);
 }

--- a/src/main/java/com/capston/favicon/config/SecurityConfig.java
+++ b/src/main/java/com/capston/favicon/config/SecurityConfig.java
@@ -5,10 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.web.cors.CorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity

--- a/src/main/java/com/capston/favicon/config/SecurityConfig.java
+++ b/src/main/java/com/capston/favicon/config/SecurityConfig.java
@@ -18,7 +18,8 @@ public class SecurityConfig {
                         csrfConfig.disable()
                 )
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/api/users/register", "/api/users/login", "/api/users/logout", "/data-table/search-sorted").permitAll()
+                        .requestMatchers("/api/users/register", "/api/users/login", "/api/users/logout",
+                                "/data-table/search-sorted", "/data-table/search-sorted/{category}").permitAll()
                         .anyRequest().authenticated()
                 )
                 .httpBasic(httpBasic -> httpBasic.disable())

--- a/src/main/java/com/capston/favicon/config/SecurityConfig.java
+++ b/src/main/java/com/capston/favicon/config/SecurityConfig.java
@@ -18,7 +18,7 @@ public class SecurityConfig {
                         csrfConfig.disable()
                 )
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/api/users/register", "/api/users/login", "/api/users/logout").permitAll()
+                        .requestMatchers("/api/users/register", "/api/users/login", "/api/users/logout", "/data-table/search-sorted").permitAll()
                         .anyRequest().authenticated()
                 )
                 .httpBasic(httpBasic -> httpBasic.disable())

--- a/src/main/java/com/capston/favicon/domain/domain/Data.java
+++ b/src/main/java/com/capston/favicon/domain/domain/Data.java
@@ -1,0 +1,27 @@
+package com.capston.favicon.domain.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+
+@Getter
+@Setter
+@Entity
+@Table(name = "datas")
+public class Data {
+
+    @Id
+    @GeneratedValue
+    private Integer data_id;
+
+    private String file_name;
+    private String category;
+    private LocalDateTime created_at;
+
+}

--- a/src/main/java/com/capston/favicon/domain/dto/SearchDto.java
+++ b/src/main/java/com/capston/favicon/domain/dto/SearchDto.java
@@ -1,0 +1,8 @@
+package com.capston.favicon.domain.dto;
+
+import lombok.Getter;
+
+@Getter
+public class SearchDto {
+    private String text;
+}

--- a/src/main/java/com/capston/favicon/infrastructure/DataRepository.java
+++ b/src/main/java/com/capston/favicon/infrastructure/DataRepository.java
@@ -1,0 +1,23 @@
+package com.capston.favicon.infrastructure;
+
+
+import com.capston.favicon.domain.domain.Data;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+
+@Repository
+public interface DataRepository extends JpaRepository<Data, Integer> {
+
+    @Query(value = """
+    SELECT * FROM datas
+    WHERE file_name ILIKE CONCAT('%', :keyword, '%')
+    ORDER BY similarity(file_name, :keyword) DESC, created_at DESC
+    """, nativeQuery = true)
+    List<Data> searchByText(@Param("keyword") String keyword);
+
+}

--- a/src/main/java/com/capston/favicon/infrastructure/DataRepository.java
+++ b/src/main/java/com/capston/favicon/infrastructure/DataRepository.java
@@ -20,4 +20,11 @@ public interface DataRepository extends JpaRepository<Data, Integer> {
     """, nativeQuery = true)
     List<Data> searchByText(@Param("keyword") String keyword);
 
+    @Query(value = """
+    SELECT * FROM datas
+    WHERE file_name ILIKE CONCAT('%', :keyword, '%')
+    AND category = :category
+    ORDER BY similarity(file_name, :keyword) DESC, created_at DESC
+    """, nativeQuery = true)
+    List<Data> searchWithCategory(@Param("keyword") String keyword, @Param("category") String category);
 }

--- a/src/main/java/com/capston/favicon/presentation/controller/DataController.java
+++ b/src/main/java/com/capston/favicon/presentation/controller/DataController.java
@@ -1,0 +1,34 @@
+package com.capston.favicon.presentation.controller;
+
+
+import com.capston.favicon.application.repository.DataService;
+import com.capston.favicon.config.APIResponse;
+import com.capston.favicon.domain.domain.Data;
+import com.capston.favicon.domain.dto.SearchDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+public class DataController {
+
+    @Autowired
+    private DataService dataService;
+
+    @GetMapping("/data-table/search-sorted")
+    public ResponseEntity<APIResponse<?>> search(@RequestBody SearchDto searchDto) {
+        try {
+            List<Data> dataList = dataService.search(searchDto.getText());
+            return ResponseEntity.ok().body(APIResponse.successAPI("검색결과", dataList));
+        } catch (Exception e) {
+            String message = e.getMessage();
+            return ResponseEntity.badRequest().body(APIResponse.errorAPI(message));
+        }
+
+    }
+
+}

--- a/src/main/java/com/capston/favicon/presentation/controller/DataController.java
+++ b/src/main/java/com/capston/favicon/presentation/controller/DataController.java
@@ -7,9 +7,7 @@ import com.capston.favicon.domain.domain.Data;
 import com.capston.favicon.domain.dto.SearchDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -28,7 +26,17 @@ public class DataController {
             String message = e.getMessage();
             return ResponseEntity.badRequest().body(APIResponse.errorAPI(message));
         }
+    }
 
+    @GetMapping("/data-table/search-sorted/{category}")
+    public ResponseEntity<APIResponse<?>> searchWithCategory(@PathVariable("category") String category, @RequestBody SearchDto searchDto) {
+        try {
+            List<Data> dataList = dataService.searchWithCategory(searchDto.getText(), category);
+            return ResponseEntity.ok().body(APIResponse.successAPI("검색결과", dataList));
+        } catch (Exception e) {
+            String message = e.getMessage();
+            return ResponseEntity.badRequest().body(APIResponse.errorAPI(message));
+        }
     }
 
 }


### PR DESCRIPTION
## 💫 관련 이슈
데이터 검색

## 📌 내용 요약
데이터 파일 검색 기능을 추가했습니다

## 🧑🏻‍💻 작업 내용
카테고리 내에서, 혹은 전체에서 데이터 파일을 검색
검색한 텍스트와 가장 많이 겹치는 데이터 파일 순으로 정렬
정렬 레벨이 같으면 최근에 업데이트 된 순으로 정렬
검색 언어는 한글과 영어로 제한

## ✅ 추가 사항
postgres에 접속하여 다음 명령어를 입력해줘야 제대로 작동합니다.
한번만 설정해두면 됩니다.
개인 데베로 테스트할 때 참고해주세요.
[한글 텍스트 검색 기능 추가]
CREATE TEXT SEARCH CONFIGURATION korean ( COPY = simple );
ALTER TEXT SEARCH CONFIGURATION korean ADD MAPPING FOR hword, hword_part, word WITH simple;
