### PR TITLE
데이터 및 테마 관련 기능들

### DIFF
--- a/src/main/java/com/capstone/favicon/dataset/application/DatasetService.java
+++ b/src/main/java/com/capstone/favicon/dataset/application/DatasetService.java
@@ -1,0 +1,53 @@
+package com.capstone.favicon.dataset.application;
+
+import com.capstone.favicon.dataset.domain.Dataset;
+import com.capstone.favicon.dataset.domain.DatasetTheme;
+import com.capstone.favicon.dataset.repository.DatasetRepository;
+import com.capstone.favicon.dataset.repository.DatasetThemeRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class DatasetService {
+
+    private final DatasetRepository datasetRepository;
+
+    private DatasetThemeRepository datasetThemeRepository;
+
+    @Autowired
+    public DatasetService(DatasetRepository datasetRepository) {
+        this.datasetRepository = datasetRepository;
+    }
+
+    public List<Dataset> findAllDatasets() {
+        return datasetRepository.findAll();
+    }
+
+    public List<Dataset> getTop10ByDownload() {
+        return datasetRepository.findTop10ByOrderByDownloadDesc();
+    }
+
+    @Transactional
+    public void incrementDownloadCount(Long datasetId) {
+        Dataset dataset = datasetRepository.findById(datasetId).orElseThrow(() -> new RuntimeException("Dataset not found with id: " + datasetId));
+        dataset.setDownload(dataset.getDownload() + 1);
+        datasetRepository.save(dataset);
+    }
+
+    public List<DatasetTheme> filterByCategory(String theme) {
+        return datasetThemeRepository.findByTheme(theme);
+    }
+
+    public long getTotalDatasetCount() {
+        return datasetRepository.count();
+    }
+
+    public Optional<Dataset> getDatasetDetails(Long datasetId) {
+        return datasetRepository.findById(datasetId);
+    }
+
+}

--- a/src/main/java/com/capstone/favicon/dataset/application/DatasetThemeService.java
+++ b/src/main/java/com/capstone/favicon/dataset/application/DatasetThemeService.java
@@ -1,0 +1,84 @@
+package com.capstone.favicon.dataset.application;
+
+import com.capstone.favicon.dataset.domain.DatasetTheme;
+import com.capstone.favicon.dataset.repository.DatasetThemeRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class DatasetThemeService {
+
+    private final DatasetThemeRepository datasetThemeRepository;
+
+    @Autowired
+    public DatasetThemeService(DatasetThemeRepository datasetThemeRepository) {
+        this.datasetThemeRepository = datasetThemeRepository;
+    }
+
+    public List<DatasetTheme> getFilteredDatasets(String region, Integer dataYear, String fileType) {
+        return datasetThemeRepository.findByRegionAndDataYearAndFileType(region, dataYear, fileType);
+    }
+
+    public List<DatasetTheme> getDatasetsByRegionAndDataYear(String region, Integer dataYear) {
+        return datasetThemeRepository.findByRegionAndDataYear(region, dataYear);
+    }
+
+    public List<DatasetTheme> getDatasetsByRegionAndFileType(String region, String fileType) {
+        return datasetThemeRepository.findByRegionAndFileType(region, fileType);
+    }
+
+    public List<DatasetTheme> getDatasetsByDataYearAndFileType(Integer dataYear, String fileType) {
+        return datasetThemeRepository.findByDataYearAndFileType(dataYear, fileType);
+    }
+
+    public List<DatasetTheme> getDatasetsByRegion(String region) {
+        return datasetThemeRepository.findByRegion(region);
+    }
+
+    public List<DatasetTheme> getDatasetsByDataYear(Integer dataYear) {
+        return datasetThemeRepository.findByDataYear(dataYear);
+    }
+
+    public List<DatasetTheme> getDatasetsByFileType(String fileType) {
+        return datasetThemeRepository.findByFileType(fileType);
+    }
+
+    public List<DatasetTheme> getAllDatasets() {
+        return datasetThemeRepository.findAll();
+    }
+
+    private long getTotalDatasetCount() {
+        return datasetThemeRepository.count();
+    }
+
+    public Object getThemeRatio() {
+        long total = getTotalDatasetCount();
+
+        if (total == 0) {
+            return new Object() {
+                public final double climate = 0.0;
+                public final double environment = 0.0;
+                public final double disease = 0.0;
+            };
+        }
+
+        long climateCount = datasetThemeRepository.countByTheme("기후");
+        long environmentCount = datasetThemeRepository.countByTheme("환경");
+        long diseaseCount = datasetThemeRepository.countByTheme("질병");
+
+        double climateRatio = (double) climateCount / total;
+        double environmentRatio = (double) environmentCount / total;
+        double diseaseRatio = (double) diseaseCount / total;
+
+        return new Object() {
+            public final double climate = climateRatio;
+            public final double environment = environmentRatio;
+            public final double disease = diseaseRatio;
+        };
+    }
+
+}
+
+

--- a/src/main/java/com/capstone/favicon/dataset/controller/DatasetController.java
+++ b/src/main/java/com/capstone/favicon/dataset/controller/DatasetController.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Optional;
 
 @RestController
-@RequestMapping("/api/dataset")
+@RequestMapping("/data-set")
 public class DatasetController {
 
     private final DatasetService datasetService;

--- a/src/main/java/com/capstone/favicon/dataset/controller/DatasetController.java
+++ b/src/main/java/com/capstone/favicon/dataset/controller/DatasetController.java
@@ -1,0 +1,51 @@
+package com.capstone.favicon.dataset.controller;
+
+import com.capstone.favicon.dataset.domain.Dataset;
+import com.capstone.favicon.dataset.domain.DatasetTheme;
+import com.capstone.favicon.dataset.application.DatasetService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/dataset")
+public class DatasetController {
+
+    private final DatasetService datasetService;
+
+    public DatasetController(DatasetService datasetService) {
+        this.datasetService = datasetService;
+    }
+
+    @GetMapping
+    public List<Dataset> getDatasets() {
+        return datasetService.findAllDatasets();
+    }
+
+    @GetMapping("/top10")
+    public List<Dataset> getTop10Datasets() {
+        return datasetService.getTop10ByDownload();
+    }
+
+    @PostMapping("/incrementDownload/{datasetId}")
+    public void incrementDownload(@PathVariable Long datasetId) {
+        datasetService.incrementDownloadCount(datasetId);
+    }
+
+    @GetMapping("/theme")
+    public List<DatasetTheme> filterByCategory(@RequestParam String theme) {
+        return datasetService.filterByCategory(theme);
+    }
+
+    @GetMapping("/count")
+    public long getTotalDatasetCount() {
+        return datasetService.getTotalDatasetCount();
+    }
+
+    @GetMapping("/{datasetId}")
+    public Optional<Dataset> getDatasetDetails(@PathVariable Long datasetId) {
+        return datasetService.getDatasetDetails(datasetId);
+    }
+
+}

--- a/src/main/java/com/capstone/favicon/dataset/controller/DatasetThemeController.java
+++ b/src/main/java/com/capstone/favicon/dataset/controller/DatasetThemeController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/dataset")
+@RequestMapping("/data-set")
 public class DatasetThemeController {
 
     private final DatasetThemeService datasetThemeService;

--- a/src/main/java/com/capstone/favicon/dataset/controller/DatasetThemeController.java
+++ b/src/main/java/com/capstone/favicon/dataset/controller/DatasetThemeController.java
@@ -1,0 +1,56 @@
+package com.capstone.favicon.dataset.controller;
+
+import com.capstone.favicon.dataset.domain.DatasetTheme;
+import com.capstone.favicon.dataset.application.DatasetThemeService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/dataset")
+public class DatasetThemeController {
+
+    private final DatasetThemeService datasetThemeService;
+
+    @Autowired
+    public DatasetThemeController(DatasetThemeService datasetThemeService) {
+        this.datasetThemeService = datasetThemeService;
+    }
+
+    @GetMapping("/filter")
+    public List<DatasetTheme> getFilteredDatasets(
+            @RequestParam(name = "region", required = false) String region,
+            @RequestParam(name = "dataYear", required = false) Integer dataYear,
+            @RequestParam(name = "fileType", required = false) String fileType) {
+
+        if (region != null && dataYear != null && fileType != null) {
+            return datasetThemeService.getFilteredDatasets(region, dataYear, fileType);
+        } else if (region != null && dataYear != null) {
+            return datasetThemeService.getDatasetsByRegionAndDataYear(region, dataYear);
+        } else if (region != null && fileType != null) {
+            return datasetThemeService.getDatasetsByRegionAndFileType(region, fileType);
+        } else if (dataYear != null && fileType != null) {
+            return datasetThemeService.getDatasetsByDataYearAndFileType(dataYear, fileType);
+        } else if (region != null) {
+            return datasetThemeService.getDatasetsByRegion(region);
+        } else if (dataYear != null) {
+            return datasetThemeService.getDatasetsByDataYear(dataYear);
+        } else if (fileType != null) {
+            return datasetThemeService.getDatasetsByFileType(fileType);
+        } else {
+            return datasetThemeService.getAllDatasets();
+        }
+    }
+
+    @GetMapping("/ratio")
+    public Object getThemeRatio() {
+        return datasetThemeService.getThemeRatio();
+    }
+
+}
+
+

--- a/src/main/java/com/capstone/favicon/dataset/domain/DatasetTheme.java
+++ b/src/main/java/com/capstone/favicon/dataset/domain/DatasetTheme.java
@@ -1,0 +1,26 @@
+package com.capstone.favicon.dataset.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "dataset_theme")
+public class DatasetTheme {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long datasetThemeId;
+
+    @ManyToOne
+    @JoinColumn(name = "dataset_id", nullable = false)
+    private Dataset dataset;
+
+    private String name;
+    private String theme;
+    private String region;
+    private Integer dataYear;
+    private String fileType;
+}

--- a/src/main/java/com/capstone/favicon/dataset/repository/DatasetRepository.java
+++ b/src/main/java/com/capstone/favicon/dataset/repository/DatasetRepository.java
@@ -4,7 +4,9 @@ import com.capstone.favicon.dataset.domain.Dataset;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface DatasetRepository extends JpaRepository<Dataset, Long> {
-
+    List<Dataset> findTop10ByOrderByDownloadDesc();
 }

--- a/src/main/java/com/capstone/favicon/dataset/repository/DatasetThemeRepository.java
+++ b/src/main/java/com/capstone/favicon/dataset/repository/DatasetThemeRepository.java
@@ -1,0 +1,26 @@
+package com.capstone.favicon.dataset.repository;
+
+import com.capstone.favicon.dataset.domain.DatasetTheme;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface DatasetThemeRepository extends JpaRepository<DatasetTheme, Long> {
+
+    List<DatasetTheme> findByTheme(String theme);
+
+    List<DatasetTheme> findByRegionAndDataYearAndFileType(String region, int dataYear, String fileType);
+
+    List<DatasetTheme> findByRegionAndDataYear(String region, int dataYear);
+    List<DatasetTheme> findByRegionAndFileType(String region, String fileType);
+    List<DatasetTheme> findByDataYearAndFileType(int dataYear, String fileType);
+
+    List<DatasetTheme> findByRegion(String region);
+
+    List<DatasetTheme> findByDataYear(int dataYear);
+
+    List<DatasetTheme> findByFileType(String fileType);
+
+    long countByTheme(String theme);
+}
+


### PR DESCRIPTION
## 💫 관련 이슈
데이터 및 테마 관련 기능들

## 📌 내용 요약
메인 및 데이터 비율 상세정보 등 필요한 기능들을 추가하였습니다.


## 🧑🏻‍💻 작업 내용
[메인 페이지]
상위 인기데이터 10개 조회 기능(다운로드 수 기준)
datasetId를 활용한 해당 데이터 셋의 다운로드 수 증가 기능
카테고리별(기후,환경,질병) 비중을 나타내는 기능
전체 데이터 개수 조회

[데이터 목록]
필터링 기능
데이터 상세정보 기능

## ✅ 추가 사항
구현된 몇몇 기능들은 사용은 안하지만 추후에 필요할 경우 쓸 수 있게끔 일단 냅뒀습니다!
category 테이블은 datasetTheme 테이블로 하는 걸로 하고 name 속성 추가해서 감기, 수질과 같은 세부 속성 넣을 수 있도록 했는데 어떨까요?